### PR TITLE
fix: add role="alert" to login error message

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -53,7 +53,7 @@ export default function LoginPage() {
         <CardContent>
           <form onSubmit={handleSubmit} className="space-y-4">
             {error && (
-              <div className="p-3 bg-red-50 border border-red-200 rounded-md text-red-700 text-sm">
+              <div role="alert" className="p-3 bg-red-50 border border-red-200 rounded-md text-red-700 text-sm">
                 {error}
               </div>
             )}


### PR DESCRIPTION
## Summary

Adds `role="alert"` to the login error message div.

## Benefits

- Allows E2E tests to locate the error using `getByRole('alert')`
- Improves accessibility for screen readers

## Test plan

- [x] E2E tests in AcctAtlas-integration-tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)