### PR TITLE
feat: support Mapbox token as Docker build argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,13 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
+# Build arguments for Next.js public environment variables
+# These are inlined at build time into the client-side JavaScript
+ARG NEXT_PUBLIC_API_URL=http://localhost:8080/api/v1
+ARG NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=$NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
+
 # Copy package files
 COPY package.json package-lock.json ./
 


### PR DESCRIPTION
## Summary
- Add `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN` as a Docker build argument
- Next.js requires `NEXT_PUBLIC_*` variables to be present at build time for client-side code
- Without this, the map page fails with "Mapbox token not configured"

## Test plan
- [x] Build Docker image with Mapbox token: `docker build --build-arg NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=<token> .`
- [x] Verify map page loads without "Mapbox token not configured" error

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)