### PR TITLE
test: add data-testid to MiniMap for E2E testing

### DIFF
--- a/src/components/video/MiniMap.tsx
+++ b/src/components/video/MiniMap.tsx
@@ -12,6 +12,7 @@ interface MiniMapProps {
 export function MiniMap({ latitude, longitude }: MiniMapProps) {
   return (
     <div
+      data-testid="mini-map"
       className="rounded-lg overflow-hidden border border-gray-200"
       style={{ height: 250 }}
     >


### PR DESCRIPTION
## Summary
- Add `data-testid="mini-map"` to MiniMap component wrapper div for reliable E2E test targeting

## Test plan
- [x] Deployed web-app and verified mini-map still renders correctly
- [x] New E2E tests in integration-tests repo pass across Chromium, Firefox, and WebKit (see companion PR)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)