### PR TITLE
feat: add SECURITY participant type

### DIFF
--- a/docs/map-integration.md
+++ b/docs/map-integration.md
@@ -249,10 +249,10 @@ The frontend transforms API responses to match internal types:
 
 Filters use API-compatible values (uppercase enum names):
 
-| Filter       | Values                                             |
-| ------------ | -------------------------------------------------- |
-| Amendments   | `FIRST`, `SECOND`, `FOURTH`, `FIFTH`, `FOURTEENTH` |
-| Participants | `POLICE`, `GOVERNMENT`, `BUSINESS`, `CITIZEN`      |
+| Filter       | Values                                                    |
+| ------------ | --------------------------------------------------------- |
+| Amendments   | `FIRST`, `SECOND`, `FOURTH`, `FIFTH`, `FOURTEENTH`        |
+| Participants | `POLICE`, `GOVERNMENT`, `BUSINESS`, `CITIZEN`, `SECURITY` |
 
 Display formatting converts these to user-friendly labels (e.g., `FIRST` → `1st`).
 

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -97,16 +97,8 @@ export interface VideoDetails {
   recordedAt?: string;
   createdAt: string;
   amendments: string[];
-  participants: Participant[];
+  participants: string[];
   location?: LocationDetails;
-}
-
-// Participant in a video
-export interface Participant {
-  id: string;
-  name: string;
-  role?: string;
-  organizationType?: string;
 }
 
 // Amendment filter options
@@ -159,4 +151,5 @@ export const PARTICIPANT_TYPE_OPTIONS = [
   { id: "GOVERNMENT", label: "Government" },
   { id: "BUSINESS", label: "Business" },
   { id: "CITIZEN", label: "Citizen" },
+  { id: "SECURITY", label: "Security" },
 ];


### PR DESCRIPTION
## Summary
- Add `{ id: "SECURITY", label: "Security" }` to `PARTICIPANT_TYPE_OPTIONS`
- Remove dead `Participant` interface (was unused; actual API returns `string[]`)
- Fix `VideoDetails.participants` type from `Participant[]` to `string[]`
- Update `docs/map-integration.md` filter values table

Closes #50

Part of cross-cutting change: [AccountabilityAtlas#46](https://github.com/kelleyglenn/AccountabilityAtlas/issues/46)

## Test plan
- [x] `npm run build` passes (no type errors)
- [x] Full stack deployed and verified (107 API + 138 E2E tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)