### PR TITLE
fix: add .gitattributes for LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Normalize all text files to LF line endings
+* text=auto eol=lf


### PR DESCRIPTION
## Summary
- Add `.gitattributes` with `* text=auto eol=lf` to prevent phantom CRLF diffs on Windows
- Prettier writes LF, but `core.autocrlf=true` checks out as CRLF, causing 33 files to appear modified

## Test plan
- [x] After adding `.gitattributes`, `git status` shows clean working tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)