### PR TITLE
feat: map thumbnailUrl, duration, videoDate from search API

### DIFF
--- a/src/__tests__/lib/api/search.test.ts
+++ b/src/__tests__/lib/api/search.test.ts
@@ -81,6 +81,38 @@ describe("api/search", () => {
 
       expect(result.videos[0].participantCount).toBe(3);
     });
+
+    it("maps thumbnailUrl, durationSeconds, and videoDate from API response", async () => {
+      const apiResponse = makeApiResponse([
+        makeResult({
+          thumbnailUrl: "https://img.youtube.com/vi/abc123/mqdefault.jpg",
+          durationSeconds: 185,
+          videoDate: "2025-06-15",
+        }),
+      ]);
+
+      (apiClient.get as jest.Mock).mockResolvedValue({ data: apiResponse });
+
+      const result = await searchVideos({ page: 0, pageSize: 20 });
+
+      expect(result.videos[0].thumbnailUrl).toBe(
+        "https://img.youtube.com/vi/abc123/mqdefault.jpg"
+      );
+      expect(result.videos[0].duration).toBe(185);
+      expect(result.videos[0].recordedAt).toBe("2025-06-15");
+    });
+
+    it("handles missing thumbnailUrl, durationSeconds, and videoDate gracefully", async () => {
+      const apiResponse = makeApiResponse([makeResult()]);
+
+      (apiClient.get as jest.Mock).mockResolvedValue({ data: apiResponse });
+
+      const result = await searchVideos({ page: 0, pageSize: 20 });
+
+      expect(result.videos[0].thumbnailUrl).toBeUndefined();
+      expect(result.videos[0].duration).toBeUndefined();
+      expect(result.videos[0].recordedAt).toBeUndefined();
+    });
   });
 
   describe("query parameter handling", () => {

--- a/src/lib/api/search.ts
+++ b/src/lib/api/search.ts
@@ -25,6 +25,9 @@ interface ApiSearchResult {
   title: string;
   description?: string;
   channelName?: string;
+  thumbnailUrl?: string;
+  durationSeconds?: number;
+  videoDate?: string;
   amendments: string[];
   participants: string[];
   locations: Array<{
@@ -65,6 +68,9 @@ function transformSearchResponse(
         latitude: primaryLocation.coordinates.latitude,
         longitude: primaryLocation.coordinates.longitude,
         title: result.title,
+        thumbnailUrl: result.thumbnailUrl,
+        duration: result.durationSeconds,
+        recordedAt: result.videoDate,
         amendments: result.amendments,
         participantCount: result.participants.length,
       };


### PR DESCRIPTION
## Summary
- Maps `thumbnailUrl`, `durationSeconds`, and `videoDate` from search API response to `VideoLocation` objects
- Video list items and info cards now display YouTube thumbnails instead of gray placeholders
- Duration badges and video dates also now display (were already supported in UI but never populated)

Closes AccountabilityAtlas/AccountabilityAtlas#31

## Changes
- `src/lib/api/search.ts`: Added 3 fields to `ApiSearchResult` interface and `transformSearchResponse()` mapping
- `src/__tests__/lib/api/search.test.ts`: Added tests for field mapping and graceful handling of missing values

## Test plan
- [x] Unit tests pass (`npx jest` — 339/339)
- [x] Deploy via `deploy.sh web-app`
- [x] Integration tests pass (`npm run test:all` — 278/278)
- [x] Visual verification: thumbnails visible in video list and info cards on map page

🤖 Generated with [Claude Code](https://claude.com/claude-code)