### PR TITLE
feat: UI polish — page titles, login redirect, avatar, public profile link, map home button

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -24,6 +24,12 @@ const customJestConfig = {
     ],
   ],
   coverageThreshold: {
+    global: {
+      statements: 75,
+      branches: 65,
+      functions: 70,
+      lines: 75,
+    },
     "./src/hooks/": {
       statements: 80,
       branches: 80,
@@ -49,10 +55,10 @@ const customJestConfig = {
       lines: 80,
     },
     "./src/components/map/": {
-      statements: 44,
-      branches: 47,
-      functions: 48,
-      lines: 46,
+      statements: 55,
+      branches: 55,
+      functions: 50,
+      lines: 55,
     },
   },
 };

--- a/src/__tests__/app/layouts.test.tsx
+++ b/src/__tests__/app/layouts.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import LoginLayout, { metadata as loginMetadata } from "@/app/login/layout";
+import RegisterLayout, {
+  metadata as registerMetadata,
+} from "@/app/register/layout";
+import MapLayout, { metadata as mapMetadata } from "@/app/map/layout";
+import ProfileLayout, {
+  metadata as profileMetadata,
+} from "@/app/profile/layout";
+import SubmitVideoLayout, {
+  metadata as submitMetadata,
+} from "@/app/videos/new/layout";
+
+describe("Route layouts", () => {
+  describe("metadata exports", () => {
+    it("login layout exports correct title", () => {
+      expect(loginMetadata).toEqual({ title: "Sign In" });
+    });
+
+    it("register layout exports correct title", () => {
+      expect(registerMetadata).toEqual({ title: "Register" });
+    });
+
+    it("map layout exports correct title", () => {
+      expect(mapMetadata).toEqual({ title: "Map" });
+    });
+
+    it("profile layout exports correct title", () => {
+      expect(profileMetadata).toEqual({ title: "My Profile" });
+    });
+
+    it("submit video layout exports correct title", () => {
+      expect(submitMetadata).toEqual({ title: "Submit Video" });
+    });
+  });
+
+  describe("layout rendering", () => {
+    it("login layout renders children", () => {
+      render(
+        <LoginLayout>
+          <span>child</span>
+        </LoginLayout>
+      );
+      expect(screen.getByText("child")).toBeInTheDocument();
+    });
+
+    it("register layout renders children", () => {
+      render(
+        <RegisterLayout>
+          <span>child</span>
+        </RegisterLayout>
+      );
+      expect(screen.getByText("child")).toBeInTheDocument();
+    });
+
+    it("map layout renders children", () => {
+      render(
+        <MapLayout>
+          <span>child</span>
+        </MapLayout>
+      );
+      expect(screen.getByText("child")).toBeInTheDocument();
+    });
+
+    it("profile layout renders children", () => {
+      render(
+        <ProfileLayout>
+          <span>child</span>
+        </ProfileLayout>
+      );
+      expect(screen.getByText("child")).toBeInTheDocument();
+    });
+
+    it("submit video layout renders children", () => {
+      render(
+        <SubmitVideoLayout>
+          <span>child</span>
+        </SubmitVideoLayout>
+      );
+      expect(screen.getByText("child")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/__tests__/app/profile/ProfilePage.test.tsx
+++ b/src/__tests__/app/profile/ProfilePage.test.tsx
@@ -214,4 +214,10 @@ describe("ProfilePage", () => {
     fireEvent.click(screen.getByTestId("trigger-error"));
     expect(mockError).toHaveBeenCalledWith("test error");
   });
+
+  it("renders View public profile link", () => {
+    render(<ProfilePage />);
+    const link = screen.getByText("View public profile");
+    expect(link.closest("a")).toHaveAttribute("href", "/users/1");
+  });
 });

--- a/src/__tests__/app/users/PublicProfilePage.test.tsx
+++ b/src/__tests__/app/users/PublicProfilePage.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import PublicProfilePage from "@/app/users/[id]/page";
+import PublicProfilePage from "@/app/users/[id]/PublicProfileClient";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const mockParams = { id: "user-123" };

--- a/src/__tests__/app/users/userPage.test.tsx
+++ b/src/__tests__/app/users/userPage.test.tsx
@@ -1,0 +1,63 @@
+import { generateMetadata } from "@/app/users/[id]/page";
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+describe("users/[id]/page", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  describe("generateMetadata", () => {
+    it("returns display name on successful fetch", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ displayName: "Jane Doe" }),
+      });
+
+      const metadata = await generateMetadata({
+        params: Promise.resolve({ id: "user-123" }),
+      });
+
+      expect(metadata).toEqual({ title: "Jane Doe" });
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/users/user-123"),
+        expect.any(Object)
+      );
+    });
+
+    it("returns fallback title when response is not ok", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false });
+
+      const metadata = await generateMetadata({
+        params: Promise.resolve({ id: "bad-id" }),
+      });
+
+      expect(metadata).toEqual({ title: "User Profile" });
+    });
+
+    it("returns fallback title when fetch throws", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+      const metadata = await generateMetadata({
+        params: Promise.resolve({ id: "error-id" }),
+      });
+
+      expect(metadata).toEqual({ title: "User Profile" });
+    });
+
+    it("returns fallback title when user has no displayName", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ displayName: "" }),
+      });
+
+      const metadata = await generateMetadata({
+        params: Promise.resolve({ id: "no-name" }),
+      });
+
+      expect(metadata).toEqual({ title: "User Profile" });
+    });
+  });
+});

--- a/src/__tests__/app/videos/VideoDetailClient.test.tsx
+++ b/src/__tests__/app/videos/VideoDetailClient.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+
+const mockUseParams = jest.fn();
+jest.mock("next/navigation", () => ({
+  useParams: () => mockUseParams(),
+}));
+
+jest.mock("next/dynamic", () => {
+  return jest.fn(() => {
+    const MockComponent = ({ videoId }: { videoId: string }) => (
+      <div data-testid="video-detail">videoId={videoId}</div>
+    );
+    MockComponent.displayName = "MockVideoDetail";
+    return MockComponent;
+  });
+});
+
+import VideoDetailClient from "@/app/videos/[id]/VideoDetailClient";
+
+describe("VideoDetailClient", () => {
+  beforeEach(() => {
+    mockUseParams.mockReturnValue({ id: "test-video-id" });
+  });
+
+  it("renders VideoDetail with videoId from params", () => {
+    render(<VideoDetailClient />);
+    expect(screen.getByTestId("video-detail")).toHaveTextContent(
+      "videoId=test-video-id"
+    );
+  });
+
+  it("handles array params by using first element", () => {
+    mockUseParams.mockReturnValue({ id: ["first-id", "second-id"] });
+
+    render(<VideoDetailClient />);
+    expect(screen.getByTestId("video-detail")).toHaveTextContent(
+      "videoId=first-id"
+    );
+  });
+});

--- a/src/__tests__/app/videos/videoPage.test.tsx
+++ b/src/__tests__/app/videos/videoPage.test.tsx
@@ -1,0 +1,63 @@
+import { generateMetadata } from "@/app/videos/[id]/page";
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+describe("videos/[id]/page", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  describe("generateMetadata", () => {
+    it("returns video title on successful fetch", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ title: "Test Video Title" }),
+      });
+
+      const metadata = await generateMetadata({
+        params: Promise.resolve({ id: "abc-123" }),
+      });
+
+      expect(metadata).toEqual({ title: "Test Video Title" });
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/videos/abc-123"),
+        expect.any(Object)
+      );
+    });
+
+    it("returns fallback title when response is not ok", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false });
+
+      const metadata = await generateMetadata({
+        params: Promise.resolve({ id: "bad-id" }),
+      });
+
+      expect(metadata).toEqual({ title: "Video" });
+    });
+
+    it("returns fallback title when fetch throws", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+      const metadata = await generateMetadata({
+        params: Promise.resolve({ id: "error-id" }),
+      });
+
+      expect(metadata).toEqual({ title: "Video" });
+    });
+
+    it("returns fallback title when video has no title", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ title: "" }),
+      });
+
+      const metadata = await generateMetadata({
+        params: Promise.resolve({ id: "no-title" }),
+      });
+
+      expect(metadata).toEqual({ title: "Video" });
+    });
+  });
+});

--- a/src/__tests__/components/NavBar.test.tsx
+++ b/src/__tests__/components/NavBar.test.tsx
@@ -128,6 +128,47 @@ describe("NavBar", () => {
     });
   });
 
+  describe("avatar display", () => {
+    it("shows avatar image when user has avatarUrl", () => {
+      mockAuth = {
+        user: {
+          id: "1",
+          displayName: "Test User",
+          email: "t@t.com",
+          emailVerified: true,
+          trustTier: "NEW",
+          avatarUrl: "https://example.com/avatar.jpg",
+        },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: mockLogout,
+      };
+      render(<NavBar />);
+      const avatar = screen.getByAltText("Test User's avatar");
+      expect(avatar).toBeInTheDocument();
+      expect(avatar).toHaveAttribute("src", "https://example.com/avatar.jpg");
+      expect(avatar.closest("a")).toHaveAttribute("href", "/profile");
+    });
+
+    it("shows display name text when user has no avatarUrl", () => {
+      mockAuth = {
+        user: {
+          id: "1",
+          displayName: "Test User",
+          email: "t@t.com",
+          emailVerified: true,
+          trustTier: "NEW",
+        },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: mockLogout,
+      };
+      render(<NavBar />);
+      expect(screen.getByText("Test User")).toBeInTheDocument();
+      expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    });
+  });
+
   describe("login redirect", () => {
     it("Sign In link includes redirect param with current path", () => {
       mockPathname = "/map";

--- a/src/__tests__/components/NavBar.test.tsx
+++ b/src/__tests__/components/NavBar.test.tsx
@@ -127,4 +127,20 @@ describe("NavBar", () => {
       expect(profileLink.className).toContain("text-white");
     });
   });
+
+  describe("login redirect", () => {
+    it("Sign In link includes redirect param with current path", () => {
+      mockPathname = "/map";
+      render(<NavBar />);
+      const signInLink = screen.getByText("Sign In").closest("a");
+      expect(signInLink).toHaveAttribute("href", "/login?redirect=%2Fmap");
+    });
+
+    it("Sign In link omits redirect param on home page", () => {
+      mockPathname = "/";
+      render(<NavBar />);
+      const signInLink = screen.getByText("Sign In").closest("a");
+      expect(signInLink).toHaveAttribute("href", "/login");
+    });
+  });
 });

--- a/src/__tests__/components/NavBar.test.tsx
+++ b/src/__tests__/components/NavBar.test.tsx
@@ -150,6 +150,47 @@ describe("NavBar", () => {
       expect(avatar.closest("a")).toHaveAttribute("href", "/profile");
     });
 
+    it("shows avatar with ring on home page", () => {
+      mockPathname = "/";
+      mockAuth = {
+        user: {
+          id: "1",
+          displayName: "Test User",
+          email: "t@t.com",
+          emailVerified: true,
+          trustTier: "NEW",
+          avatarUrl: "https://example.com/avatar.jpg",
+        },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: mockLogout,
+      };
+      render(<NavBar />);
+      const avatar = screen.getByAltText("Test User's avatar");
+      expect(avatar.className).toContain("ring-2");
+      expect(avatar.className).toContain("ring-white/50");
+    });
+
+    it("shows avatar without ring on non-home page", () => {
+      mockPathname = "/map";
+      mockAuth = {
+        user: {
+          id: "1",
+          displayName: "Test User",
+          email: "t@t.com",
+          emailVerified: true,
+          trustTier: "NEW",
+          avatarUrl: "https://example.com/avatar.jpg",
+        },
+        isAuthenticated: true,
+        isLoading: false,
+        logout: mockLogout,
+      };
+      render(<NavBar />);
+      const avatar = screen.getByAltText("Test User's avatar");
+      expect(avatar.className).not.toContain("ring-2");
+    });
+
     it("shows display name text when user has no avatarUrl", () => {
       mockAuth = {
         user: {

--- a/src/__tests__/components/map/MapContainer.test.tsx
+++ b/src/__tests__/components/map/MapContainer.test.tsx
@@ -42,7 +42,7 @@ jest.mock("@/components/ui/Toast", () => ({
   ToastContainer: () => null,
 }));
 
-const mockSetViewport = jest.fn();
+const mockFlyTo = jest.fn();
 const mockSetSelectedVideoId = jest.fn();
 jest.mock("@/providers/MapProvider", () => ({
   useMap: () => ({
@@ -50,11 +50,10 @@ jest.mock("@/providers/MapProvider", () => ({
     viewport: { longitude: -98.58, latitude: 39.83, zoom: 4 },
     filters: { amendments: [], participants: [] },
     selectedVideoId: null,
-    setViewport: mockSetViewport,
     setSelectedVideoId: mockSetSelectedVideoId,
     highlightedVideoId: null,
     setHighlightedVideoId: jest.fn(),
-    flyTo: jest.fn(),
+    flyTo: mockFlyTo,
     pendingFlyTo: null,
     clearPendingFlyTo: jest.fn(),
     fitBounds: jest.fn(),
@@ -125,14 +124,10 @@ describe("MapContainer", () => {
       expect(screen.getByLabelText("Reset map view")).toBeInTheDocument();
     });
 
-    it("resets viewport and clears selection on click", () => {
+    it("calls flyTo with default viewport and clears selection on click", () => {
       render(<MapContainer />);
       fireEvent.click(screen.getByLabelText("Reset map view"));
-      expect(mockSetViewport).toHaveBeenCalledWith({
-        longitude: -98.5795,
-        latitude: 39.8283,
-        zoom: 4,
-      });
+      expect(mockFlyTo).toHaveBeenCalledWith(-98.5795, 39.8283, 4);
       expect(mockSetSelectedVideoId).toHaveBeenCalledWith(null);
     });
   });

--- a/src/__tests__/components/map/MapContainer.test.tsx
+++ b/src/__tests__/components/map/MapContainer.test.tsx
@@ -132,6 +132,14 @@ describe("MapContainer", () => {
     });
   });
 
+  describe("loading state", () => {
+    it("shows loading placeholder when isClient is false", () => {
+      mockResponsive = { isMobile: false, isClient: false };
+      render(<MapContainer />);
+      expect(screen.getByText("Loading map...")).toBeInTheDocument();
+    });
+  });
+
   describe("search bar translucency", () => {
     it("search bar wrapper has opacity-60 class in desktop layout", () => {
       render(<MapContainer />);

--- a/src/__tests__/components/map/MapContainer.test.tsx
+++ b/src/__tests__/components/map/MapContainer.test.tsx
@@ -1,0 +1,151 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MapContainer } from "@/components/map/MapContainer";
+
+// Mock all child components as simple divs
+jest.mock("@/components/map/MapView", () => ({
+  MapView: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="map-view">{children}</div>
+  ),
+}));
+jest.mock("@/components/map/VideoMarker", () => ({
+  VideoMarker: () => <div data-testid="video-marker" />,
+}));
+jest.mock("@/components/map/ClusterMarker", () => ({
+  ClusterMarker: () => <div data-testid="cluster-marker" />,
+}));
+jest.mock("@/components/map/VideoInfoCard", () => ({
+  VideoInfoCard: () => <div data-testid="video-info-card" />,
+}));
+jest.mock("@/components/map/SidePanel", () => ({
+  SidePanel: () => <div data-testid="side-panel" />,
+}));
+jest.mock("@/components/map/BottomSheet", () => ({
+  BottomSheet: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="bottom-sheet">{children}</div>
+  ),
+}));
+jest.mock("@/components/map/LocationSearch", () => ({
+  LocationSearch: () => <div data-testid="location-search" />,
+}));
+jest.mock("@/components/map/VideoListItem", () => ({
+  VideoListItem: () => <div data-testid="video-list-item" />,
+}));
+jest.mock("@/components/map/FilterBar", () => ({
+  FilterBar: () => <div data-testid="filter-bar" />,
+}));
+jest.mock("@/components/ui/Toast", () => ({
+  useToasts: () => ({
+    toasts: [],
+    dismissToast: jest.fn(),
+    success: jest.fn(),
+  }),
+  ToastContainer: () => null,
+}));
+
+const mockSetViewport = jest.fn();
+const mockSetSelectedVideoId = jest.fn();
+jest.mock("@/providers/MapProvider", () => ({
+  useMap: () => ({
+    bounds: [-130, 20, -60, 50],
+    viewport: { longitude: -98.58, latitude: 39.83, zoom: 4 },
+    filters: { amendments: [], participants: [] },
+    selectedVideoId: null,
+    setViewport: mockSetViewport,
+    setSelectedVideoId: mockSetSelectedVideoId,
+    highlightedVideoId: null,
+    setHighlightedVideoId: jest.fn(),
+    flyTo: jest.fn(),
+    pendingFlyTo: null,
+    clearPendingFlyTo: jest.fn(),
+    fitBounds: jest.fn(),
+    pendingFitBounds: null,
+    clearPendingFitBounds: jest.fn(),
+    setFilters: jest.fn(),
+    updateFilters: jest.fn(),
+    clearFilters: jest.fn(),
+    setBounds: jest.fn(),
+  }),
+}));
+
+jest.mock("@/hooks/useVideoSearch", () => ({
+  useVideoSearch: () => ({ data: { videos: [], total: 0 }, isLoading: false }),
+}));
+
+jest.mock("@/hooks/useLocationClusters", () => ({
+  useLocationClusters: () => ({ data: { clusters: [] } }),
+}));
+
+// For desktop rendering
+let mockResponsive = { isMobile: false, isClient: true };
+jest.mock("@/hooks/useResponsive", () => ({
+  useResponsive: () => mockResponsive,
+}));
+
+jest.mock("@/config/mapbox", () => ({
+  DEFAULT_VIEWPORT: { longitude: -98.5795, latitude: 39.8283, zoom: 4 },
+  MAP_CONFIG: {
+    minZoom: 2,
+    maxZoom: 18,
+    clusterZoomThreshold: 8,
+    maxVideosInPanel: 50,
+    moveDebounceMs: 300,
+    flyToDurationMs: 1500,
+    fitBoundsPadding: 50,
+  },
+  MAPBOX_ACCESS_TOKEN: "test-token",
+  MAPBOX_STYLE: "mapbox://styles/mapbox/streets-v12",
+  MARKER_COLORS: {
+    default: "#3B82F6",
+    selected: "#EF4444",
+    highlighted: "#F59E0B",
+    cluster: "#6366F1",
+  },
+  MARKER_SIZES: {
+    default: 24,
+    selected: 32,
+    cluster: { small: 30, medium: 40, large: 50 },
+  },
+}));
+
+describe("MapContainer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockResponsive = { isMobile: false, isClient: true };
+  });
+
+  describe("home button", () => {
+    it("renders reset map view button in desktop layout", () => {
+      render(<MapContainer />);
+      expect(screen.getByLabelText("Reset map view")).toBeInTheDocument();
+    });
+
+    it("renders reset map view button in mobile layout", () => {
+      mockResponsive = { isMobile: true, isClient: true };
+      render(<MapContainer />);
+      expect(screen.getByLabelText("Reset map view")).toBeInTheDocument();
+    });
+
+    it("resets viewport and clears selection on click", () => {
+      render(<MapContainer />);
+      fireEvent.click(screen.getByLabelText("Reset map view"));
+      expect(mockSetViewport).toHaveBeenCalledWith({
+        longitude: -98.5795,
+        latitude: 39.8283,
+        zoom: 4,
+      });
+      expect(mockSetSelectedVideoId).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe("search bar translucency", () => {
+    it("search bar wrapper has opacity-60 class in desktop layout", () => {
+      render(<MapContainer />);
+      const resetButton = screen.getByLabelText("Reset map view");
+      const wrapper = resetButton.closest("[class*='opacity-60']");
+      expect(wrapper).not.toBeNull();
+      expect(wrapper?.className).toContain("hover:opacity-100");
+      expect(wrapper?.className).toContain("focus-within:opacity-100");
+      expect(wrapper?.className).toContain("transition-opacity");
+    });
+  });
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,10 @@ import { NavBar } from "@/components/NavBar";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "AccountabilityAtlas",
+  title: {
+    template: "%s | AccountabilityAtlas",
+    default: "AccountabilityAtlas",
+  },
   description: "Geo-located video curation for constitutional rights audits",
 };
 

--- a/src/app/login/layout.tsx
+++ b/src/app/login/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sign In",
+};
+
+export default function LoginLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/map/layout.tsx
+++ b/src/app/map/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Map",
+};
+
+export default function MapLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/profile/layout.tsx
+++ b/src/app/profile/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "My Profile",
+};
+
+export default function ProfileLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -87,6 +87,12 @@ export default function ProfilePage() {
                 </p>
               )}
               <p className="text-sm text-gray-500">{user.email}</p>
+              <Link
+                href={`/users/${user.id}`}
+                className="text-sm text-blue-600 hover:underline"
+              >
+                View public profile
+              </Link>
             </div>
           </div>
         </div>

--- a/src/app/register/layout.tsx
+++ b/src/app/register/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Register",
+};
+
+export default function RegisterLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/users/[id]/PublicProfileClient.tsx
+++ b/src/app/users/[id]/PublicProfileClient.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import Link from "next/link";
+import { getPublicProfile } from "@/lib/api/users";
+
+export default function PublicProfileClient() {
+  const params = useParams();
+  const id = Array.isArray(params.id) ? params.id[0] : String(params.id);
+
+  const {
+    data: profile,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["public-profile", id],
+    queryFn: () => getPublicProfile(id),
+  });
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-lg text-gray-600">Loading...</div>
+      </div>
+    );
+  }
+
+  if (error || !profile) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center gap-4">
+        <p className="text-gray-500">User not found.</p>
+        <Link href="/map" className="text-blue-600 hover:underline">
+          Back to Map
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50 py-8 px-4">
+      <div className="max-w-lg mx-auto">
+        <div className="bg-white rounded-lg shadow-md p-6 space-y-6">
+          <div className="flex items-center gap-4">
+            {profile.avatarUrl && (
+              <img
+                src={profile.avatarUrl}
+                alt={`${profile.displayName}'s avatar`}
+                className="w-16 h-16 rounded-full object-cover"
+              />
+            )}
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900">
+                {profile.displayName}
+              </h1>
+              {profile.trustTier && (
+                <span
+                  className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800"
+                  data-testid="trust-tier-badge"
+                >
+                  {profile.trustTier}
+                </span>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-2 text-sm text-gray-600">
+            <p>
+              Member since {new Date(profile.memberSince).toLocaleDateString()}
+            </p>
+            <p>
+              {profile.approvedVideoCount} approved video
+              {profile.approvedVideoCount === 1 ? "" : "s"}
+            </p>
+          </div>
+
+          {profile.socialLinks &&
+            Object.values(profile.socialLinks).some(Boolean) && (
+              <div className="space-y-2">
+                <h2 className="text-sm font-semibold text-gray-700">
+                  Social Links
+                </h2>
+                <div className="flex flex-wrap gap-3">
+                  {profile.socialLinks.youtube && (
+                    <SocialLink
+                      label="YouTube"
+                      href={`https://youtube.com/channel/${profile.socialLinks.youtube}`}
+                    />
+                  )}
+                  {profile.socialLinks.facebook && (
+                    <SocialLink
+                      label="Facebook"
+                      href={`https://facebook.com/${profile.socialLinks.facebook}`}
+                    />
+                  )}
+                  {profile.socialLinks.instagram && (
+                    <SocialLink
+                      label="Instagram"
+                      href={`https://instagram.com/${profile.socialLinks.instagram}`}
+                    />
+                  )}
+                  {profile.socialLinks.tiktok && (
+                    <SocialLink
+                      label="TikTok"
+                      href={`https://tiktok.com/@${profile.socialLinks.tiktok}`}
+                    />
+                  )}
+                  {profile.socialLinks.xTwitter && (
+                    <SocialLink
+                      label="X"
+                      href={`https://x.com/${profile.socialLinks.xTwitter}`}
+                    />
+                  )}
+                  {profile.socialLinks.bluesky && (
+                    <SocialLink
+                      label="Bluesky"
+                      href={`https://bsky.app/profile/${profile.socialLinks.bluesky}`}
+                    />
+                  )}
+                </div>
+              </div>
+            )}
+
+          <div className="pt-4">
+            <Link
+              href="/map"
+              className="text-sm text-gray-500 hover:text-gray-700"
+            >
+              &larr; Back to Map
+            </Link>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function SocialLink({
+  label,
+  href,
+}: Readonly<{ label: string; href: string }>) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-sm text-blue-600 hover:underline"
+    >
+      {label}
+    </a>
+  );
+}

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -1,152 +1,29 @@
-"use client";
+import type { Metadata } from "next";
+import PublicProfileClient from "./PublicProfileClient";
 
-import { useParams } from "next/navigation";
-import { useQuery } from "@tanstack/react-query";
-import Link from "next/link";
-import { getPublicProfile } from "@/lib/api/users";
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080/api/v1";
 
-export default function PublicProfilePage() {
-  const params = useParams();
-  const id = Array.isArray(params.id) ? params.id[0] : String(params.id);
-
-  const {
-    data: profile,
-    isLoading,
-    error,
-  } = useQuery({
-    queryKey: ["public-profile", id],
-    queryFn: () => getPublicProfile(id),
-  });
-
-  if (isLoading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-lg text-gray-600">Loading...</div>
-      </div>
-    );
-  }
-
-  if (error || !profile) {
-    return (
-      <div className="min-h-screen flex flex-col items-center justify-center gap-4">
-        <p className="text-gray-500">User not found.</p>
-        <Link href="/map" className="text-blue-600 hover:underline">
-          Back to Map
-        </Link>
-      </div>
-    );
-  }
-
-  return (
-    <main className="min-h-screen bg-gray-50 py-8 px-4">
-      <div className="max-w-lg mx-auto">
-        <div className="bg-white rounded-lg shadow-md p-6 space-y-6">
-          <div className="flex items-center gap-4">
-            {profile.avatarUrl && (
-              <img
-                src={profile.avatarUrl}
-                alt={`${profile.displayName}'s avatar`}
-                className="w-16 h-16 rounded-full object-cover"
-              />
-            )}
-            <div>
-              <h1 className="text-2xl font-bold text-gray-900">
-                {profile.displayName}
-              </h1>
-              {profile.trustTier && (
-                <span
-                  className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800"
-                  data-testid="trust-tier-badge"
-                >
-                  {profile.trustTier}
-                </span>
-              )}
-            </div>
-          </div>
-
-          <div className="space-y-2 text-sm text-gray-600">
-            <p>
-              Member since {new Date(profile.memberSince).toLocaleDateString()}
-            </p>
-            <p>
-              {profile.approvedVideoCount} approved video
-              {profile.approvedVideoCount === 1 ? "" : "s"}
-            </p>
-          </div>
-
-          {profile.socialLinks &&
-            Object.values(profile.socialLinks).some(Boolean) && (
-              <div className="space-y-2">
-                <h2 className="text-sm font-semibold text-gray-700">
-                  Social Links
-                </h2>
-                <div className="flex flex-wrap gap-3">
-                  {profile.socialLinks.youtube && (
-                    <SocialLink
-                      label="YouTube"
-                      href={`https://youtube.com/channel/${profile.socialLinks.youtube}`}
-                    />
-                  )}
-                  {profile.socialLinks.facebook && (
-                    <SocialLink
-                      label="Facebook"
-                      href={`https://facebook.com/${profile.socialLinks.facebook}`}
-                    />
-                  )}
-                  {profile.socialLinks.instagram && (
-                    <SocialLink
-                      label="Instagram"
-                      href={`https://instagram.com/${profile.socialLinks.instagram}`}
-                    />
-                  )}
-                  {profile.socialLinks.tiktok && (
-                    <SocialLink
-                      label="TikTok"
-                      href={`https://tiktok.com/@${profile.socialLinks.tiktok}`}
-                    />
-                  )}
-                  {profile.socialLinks.xTwitter && (
-                    <SocialLink
-                      label="X"
-                      href={`https://x.com/${profile.socialLinks.xTwitter}`}
-                    />
-                  )}
-                  {profile.socialLinks.bluesky && (
-                    <SocialLink
-                      label="Bluesky"
-                      href={`https://bsky.app/profile/${profile.socialLinks.bluesky}`}
-                    />
-                  )}
-                </div>
-              </div>
-            )}
-
-          <div className="pt-4">
-            <Link
-              href="/map"
-              className="text-sm text-gray-500 hover:text-gray-700"
-            >
-              &larr; Back to Map
-            </Link>
-          </div>
-        </div>
-      </div>
-    </main>
-  );
+interface UserPageProps {
+  params: Promise<{ id: string }>;
 }
 
-function SocialLink({
-  label,
-  href,
-}: Readonly<{ label: string; href: string }>) {
-  return (
-    <a
-      href={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="text-sm text-blue-600 hover:underline"
-    >
-      {label}
-    </a>
-  );
+export async function generateMetadata({
+  params,
+}: UserPageProps): Promise<Metadata> {
+  const { id } = await params;
+  try {
+    const res = await fetch(`${API_BASE_URL}/users/${id}`, {
+      next: { revalidate: 60 },
+    });
+    if (!res.ok) return { title: "User Profile" };
+    const user = await res.json();
+    return { title: user.displayName || "User Profile" };
+  } catch {
+    return { title: "User Profile" };
+  }
+}
+
+export default function UserPage() {
+  return <PublicProfileClient />;
 }

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -2,7 +2,9 @@ import type { Metadata } from "next";
 import PublicProfileClient from "./PublicProfileClient";
 
 const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080/api/v1";
+  process.env.SERVER_API_URL ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  "http://localhost:8080/api/v1";
 
 interface UserPageProps {
   params: Promise<{ id: string }>;

--- a/src/app/videos/[id]/VideoDetailClient.tsx
+++ b/src/app/videos/[id]/VideoDetailClient.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import dynamic from "next/dynamic";
+
+const VideoDetail = dynamic(
+  () => import("@/components/video/VideoDetail").then((mod) => mod.VideoDetail),
+  { ssr: false }
+);
+
+export default function VideoDetailClient() {
+  const params = useParams();
+  const videoId = Array.isArray(params.id)
+    ? params.id[0]
+    : (params.id as string);
+
+  return <VideoDetail videoId={videoId} />;
+}

--- a/src/app/videos/[id]/page.tsx
+++ b/src/app/videos/[id]/page.tsx
@@ -2,7 +2,9 @@ import type { Metadata } from "next";
 import VideoDetailClient from "./VideoDetailClient";
 
 const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080/api/v1";
+  process.env.SERVER_API_URL ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  "http://localhost:8080/api/v1";
 
 interface VideoPageProps {
   params: Promise<{ id: string }>;

--- a/src/app/videos/[id]/page.tsx
+++ b/src/app/videos/[id]/page.tsx
@@ -1,18 +1,29 @@
-"use client";
+import type { Metadata } from "next";
+import VideoDetailClient from "./VideoDetailClient";
 
-import { useParams } from "next/navigation";
-import dynamic from "next/dynamic";
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080/api/v1";
 
-const VideoDetail = dynamic(
-  () => import("@/components/video/VideoDetail").then((mod) => mod.VideoDetail),
-  { ssr: false }
-);
+interface VideoPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: VideoPageProps): Promise<Metadata> {
+  const { id } = await params;
+  try {
+    const res = await fetch(`${API_BASE_URL}/videos/${id}`, {
+      next: { revalidate: 60 },
+    });
+    if (!res.ok) return { title: "Video" };
+    const video = await res.json();
+    return { title: video.title || "Video" };
+  } catch {
+    return { title: "Video" };
+  }
+}
 
 export default function VideoPage() {
-  const params = useParams();
-  const videoId = Array.isArray(params.id)
-    ? params.id[0]
-    : (params.id as string);
-
-  return <VideoDetail videoId={videoId} />;
+  return <VideoDetailClient />;
 }

--- a/src/app/videos/new/layout.tsx
+++ b/src/app/videos/new/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Submit Video",
+};
+
+export default function SubmitVideoLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -67,7 +67,13 @@ export function NavBar() {
             </button>
           </>
         ) : (
-          <Link href="/login">
+          <Link
+            href={
+              isHome
+                ? "/login"
+                : `/login?redirect=${encodeURIComponent(pathname)}`
+            }
+          >
             <Button
               variant="outline"
               className="text-sm"

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -5,24 +5,44 @@ import { usePathname } from "next/navigation";
 import { useAuth } from "@/providers/AuthProvider";
 import { Button } from "@/components/ui/Button";
 
-export function NavBar() {
-  const { user, isAuthenticated, logout } = useAuth();
+function useNavStyles() {
   const pathname = usePathname();
   const isHome = pathname === "/";
 
+  return {
+    isHome,
+    pathname,
+    nav: isHome ? "bg-transparent" : "bg-white border-b border-gray-200",
+    brand: isHome
+      ? "text-white hover:text-gray-200"
+      : "text-gray-900 hover:text-blue-600",
+    outlineStyle: isHome
+      ? ({ borderColor: "white", color: "white" } as const)
+      : undefined,
+    displayName: isHome
+      ? "text-white hover:text-gray-200"
+      : "text-gray-600 hover:text-blue-600",
+    avatarRing: isHome ? "ring-2 ring-white/50" : "",
+    signOut: isHome
+      ? "text-gray-300 hover:text-white"
+      : "text-gray-500 hover:text-gray-700",
+    loginHref: isHome
+      ? "/login"
+      : (`/login?redirect=${encodeURIComponent(pathname)}` as string),
+  };
+}
+
+export function NavBar() {
+  const { user, isAuthenticated, logout } = useAuth();
+  const styles = useNavStyles();
+
   return (
     <nav
-      className={`h-14 px-4 flex items-center justify-between flex-shrink-0 relative z-50 ${
-        isHome ? "bg-transparent" : "bg-white border-b border-gray-200"
-      }`}
+      className={`h-14 px-4 flex items-center justify-between flex-shrink-0 relative z-50 ${styles.nav}`}
     >
       <Link
         href="/"
-        className={`text-lg font-semibold transition-colors ${
-          isHome
-            ? "text-white hover:text-gray-200"
-            : "text-gray-900 hover:text-blue-600"
-        }`}
+        className={`text-lg font-semibold transition-colors ${styles.brand}`}
       >
         AccountabilityAtlas
       </Link>
@@ -31,9 +51,7 @@ export function NavBar() {
           <Button
             variant="outline"
             className="text-sm"
-            style={
-              isHome ? { borderColor: "white", color: "white" } : undefined
-            }
+            style={styles.outlineStyle}
           >
             Explore Map
           </Button>
@@ -50,47 +68,26 @@ export function NavBar() {
                 <img
                   src={user.avatarUrl}
                   alt={`${user.displayName}'s avatar`}
-                  className={`w-7 h-7 rounded-full object-cover ${
-                    isHome ? "ring-2 ring-white/50" : ""
-                  }`}
+                  className={`w-7 h-7 rounded-full object-cover ${styles.avatarRing}`}
                 />
               ) : (
                 <span
-                  className={`text-sm transition-colors ${
-                    isHome
-                      ? "text-white hover:text-gray-200"
-                      : "text-gray-600 hover:text-blue-600"
-                  }`}
+                  className={`text-sm transition-colors ${styles.displayName}`}
                 >
                   {user?.displayName}
                 </span>
               )}
             </Link>
-            <button
-              onClick={logout}
-              className={`text-sm ${
-                isHome
-                  ? "text-gray-300 hover:text-white"
-                  : "text-gray-500 hover:text-gray-700"
-              }`}
-            >
+            <button onClick={logout} className={`text-sm ${styles.signOut}`}>
               Sign Out
             </button>
           </>
         ) : (
-          <Link
-            href={
-              isHome
-                ? "/login"
-                : `/login?redirect=${encodeURIComponent(pathname)}`
-            }
-          >
+          <Link href={styles.loginHref}>
             <Button
               variant="outline"
               className="text-sm"
-              style={
-                isHome ? { borderColor: "white", color: "white" } : undefined
-              }
+              style={styles.outlineStyle}
             >
               Sign In
             </Button>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -45,15 +45,26 @@ export function NavBar() {
                 Submit Video
               </Button>
             </Link>
-            <Link
-              href="/profile"
-              className={`text-sm transition-colors ${
-                isHome
-                  ? "text-white hover:text-gray-200"
-                  : "text-gray-600 hover:text-blue-600"
-              }`}
-            >
-              {user?.displayName}
+            <Link href="/profile">
+              {user?.avatarUrl ? (
+                <img
+                  src={user.avatarUrl}
+                  alt={`${user.displayName}'s avatar`}
+                  className={`w-7 h-7 rounded-full object-cover ${
+                    isHome ? "ring-2 ring-white/50" : ""
+                  }`}
+                />
+              ) : (
+                <span
+                  className={`text-sm transition-colors ${
+                    isHome
+                      ? "text-white hover:text-gray-200"
+                      : "text-gray-600 hover:text-blue-600"
+                  }`}
+                >
+                  {user?.displayName}
+                </span>
+              )}
             </Link>
             <button
               onClick={logout}

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -15,11 +15,18 @@ import { BottomSheet } from "./BottomSheet";
 import { LocationSearch } from "./LocationSearch";
 import { VideoListItem } from "./VideoListItem";
 import { FilterBar } from "./FilterBar";
-import { MAP_CONFIG } from "@/config/mapbox";
+import { DEFAULT_VIEWPORT, MAP_CONFIG } from "@/config/mapbox";
 import type { VideoLocation } from "@/types/map";
 
 export function MapContainer() {
-  const { bounds, viewport, filters, selectedVideoId } = useMap();
+  const {
+    bounds,
+    viewport,
+    filters,
+    selectedVideoId,
+    setViewport,
+    setSelectedVideoId,
+  } = useMap();
   const { isMobile, isClient } = useResponsive();
   const { toasts, dismissToast, success } = useToasts();
 
@@ -117,8 +124,28 @@ export function MapContainer() {
         </MapView>
 
         {/* Search bar overlay */}
-        <div className="absolute top-4 left-4 right-4 z-30">
-          <LocationSearch onLocationSelect={handleLocationSelect} />
+        <div className="absolute top-4 left-4 right-4 z-30 flex items-start gap-2 opacity-60 hover:opacity-100 focus-within:opacity-100 transition-opacity duration-300">
+          <div className="flex-1">
+            <LocationSearch onLocationSelect={handleLocationSelect} />
+          </div>
+          <button
+            onClick={() => {
+              setViewport(DEFAULT_VIEWPORT);
+              setSelectedVideoId(null);
+            }}
+            className="flex-shrink-0 w-9 h-9 bg-white rounded-md shadow flex items-center justify-center text-gray-600 hover:text-gray-900 hover:bg-gray-50"
+            aria-label="Reset map view"
+            title="Reset map view"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className="w-5 h-5"
+            >
+              <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z" />
+            </svg>
+          </button>
         </div>
 
         {/* Bottom sheet with video list */}
@@ -201,8 +228,28 @@ export function MapContainer() {
         </MapView>
 
         {/* Search bar overlay */}
-        <div className="absolute top-4 left-4 right-4 max-w-md z-10">
-          <LocationSearch onLocationSelect={handleLocationSelect} />
+        <div className="absolute top-4 left-4 right-4 max-w-md z-10 flex items-start gap-2 opacity-60 hover:opacity-100 focus-within:opacity-100 transition-opacity duration-300">
+          <div className="flex-1">
+            <LocationSearch onLocationSelect={handleLocationSelect} />
+          </div>
+          <button
+            onClick={() => {
+              setViewport(DEFAULT_VIEWPORT);
+              setSelectedVideoId(null);
+            }}
+            className="flex-shrink-0 w-9 h-9 bg-white rounded-md shadow flex items-center justify-center text-gray-600 hover:text-gray-900 hover:bg-gray-50"
+            aria-label="Reset map view"
+            title="Reset map view"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className="w-5 h-5"
+            >
+              <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z" />
+            </svg>
+          </button>
         </div>
       </div>
 

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -18,6 +18,26 @@ import { FilterBar } from "./FilterBar";
 import { DEFAULT_VIEWPORT, MAP_CONFIG } from "@/config/mapbox";
 import type { VideoLocation } from "@/types/map";
 
+function HomeButton({ onClick }: Readonly<{ onClick: () => void }>) {
+  return (
+    <button
+      onClick={onClick}
+      className="flex-shrink-0 w-9 h-9 bg-white rounded-md shadow flex items-center justify-center text-gray-600 hover:text-gray-900 hover:bg-gray-50"
+      aria-label="Reset map view"
+      title="Reset map view"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        className="w-5 h-5"
+      >
+        <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z" />
+      </svg>
+    </button>
+  );
+}
+
 export function MapContainer() {
   const {
     bounds,
@@ -84,6 +104,15 @@ export function MapContainer() {
     success(`Moved to ${name}`);
   };
 
+  const handleResetView = () => {
+    flyTo(
+      DEFAULT_VIEWPORT.longitude,
+      DEFAULT_VIEWPORT.latitude,
+      DEFAULT_VIEWPORT.zoom
+    );
+    setSelectedVideoId(null);
+  };
+
   // Don't render until we know if we're on mobile
   if (!isClient) {
     return (
@@ -128,28 +157,7 @@ export function MapContainer() {
           <div className="flex-1">
             <LocationSearch onLocationSelect={handleLocationSelect} />
           </div>
-          <button
-            onClick={() => {
-              flyTo(
-                DEFAULT_VIEWPORT.longitude,
-                DEFAULT_VIEWPORT.latitude,
-                DEFAULT_VIEWPORT.zoom
-              );
-              setSelectedVideoId(null);
-            }}
-            className="flex-shrink-0 w-9 h-9 bg-white rounded-md shadow flex items-center justify-center text-gray-600 hover:text-gray-900 hover:bg-gray-50"
-            aria-label="Reset map view"
-            title="Reset map view"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              className="w-5 h-5"
-            >
-              <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z" />
-            </svg>
-          </button>
+          <HomeButton onClick={handleResetView} />
         </div>
 
         {/* Bottom sheet with video list */}
@@ -236,28 +244,7 @@ export function MapContainer() {
           <div className="flex-1">
             <LocationSearch onLocationSelect={handleLocationSelect} />
           </div>
-          <button
-            onClick={() => {
-              flyTo(
-                DEFAULT_VIEWPORT.longitude,
-                DEFAULT_VIEWPORT.latitude,
-                DEFAULT_VIEWPORT.zoom
-              );
-              setSelectedVideoId(null);
-            }}
-            className="flex-shrink-0 w-9 h-9 bg-white rounded-md shadow flex items-center justify-center text-gray-600 hover:text-gray-900 hover:bg-gray-50"
-            aria-label="Reset map view"
-            title="Reset map view"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              className="w-5 h-5"
-            >
-              <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z" />
-            </svg>
-          </button>
+          <HomeButton onClick={handleResetView} />
         </div>
       </div>
 

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -24,8 +24,8 @@ export function MapContainer() {
     viewport,
     filters,
     selectedVideoId,
-    setViewport,
     setSelectedVideoId,
+    flyTo,
   } = useMap();
   const { isMobile, isClient } = useResponsive();
   const { toasts, dismissToast, success } = useToasts();
@@ -130,7 +130,11 @@ export function MapContainer() {
           </div>
           <button
             onClick={() => {
-              setViewport(DEFAULT_VIEWPORT);
+              flyTo(
+                DEFAULT_VIEWPORT.longitude,
+                DEFAULT_VIEWPORT.latitude,
+                DEFAULT_VIEWPORT.zoom
+              );
               setSelectedVideoId(null);
             }}
             className="flex-shrink-0 w-9 h-9 bg-white rounded-md shadow flex items-center justify-center text-gray-600 hover:text-gray-900 hover:bg-gray-50"
@@ -234,7 +238,11 @@ export function MapContainer() {
           </div>
           <button
             onClick={() => {
-              setViewport(DEFAULT_VIEWPORT);
+              flyTo(
+                DEFAULT_VIEWPORT.longitude,
+                DEFAULT_VIEWPORT.latitude,
+                DEFAULT_VIEWPORT.zoom
+              );
               setSelectedVideoId(null);
             }}
             className="flex-shrink-0 w-9 h-9 bg-white rounded-md shadow flex items-center justify-center text-gray-600 hover:text-gray-900 hover:bg-gray-50"


### PR DESCRIPTION
## Summary

Implements 5 web-app UI polish issues on a single branch:

- **#35 — Page titles**: Root layout `title.template` (`%s | AccountabilityAtlas`), static route layouts for login/register/map/profile/submit, and server-side `generateMetadata` for dynamic video detail and public profile pages
- **#41 — Login redirect**: "Sign In" link passes `?redirect=` param with current path; login page reads it and redirects back after successful auth
- **#65 — Avatar in header**: Logged-in users see their avatar (circular, with white ring on home page) instead of display name text
- **#66 — View public profile**: Profile page includes a "View public profile" link to `/users/{id}`
- **#21 — Map search bar translucency + home button**: Search bar starts at 60% opacity (full on hover/focus), plus a home icon button that calls `flyTo()` to reset the map viewport and refresh clusters

Also fixes a Docker networking bug: added `SERVER_API_URL` env var so `generateMetadata` can reach the API gateway inside Docker (where `localhost:8080` doesn't work).

## Test plan

- [x] 421 unit tests passing (`npm test`)
- [x] Manual verification of all 5 features in browser
- [x] Full integration test suite passing (203 tests)
- [x] CI passes on this PR

Closes #21
Closes #35
Closes #41
Closes #65
Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)